### PR TITLE
Fixed not working with @babel/core@7.0.0.

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -55,7 +55,7 @@ const plugins = [
 	"jsx",
 	"typescript",
 	"objectRestSpread",
-	"decorators",
+	["decorators", { "decoratorsBeforeExport": true }],
 	"classProperties",
 	"exportExtensions",
 	"asyncGenerators",

--- a/extract.js
+++ b/extract.js
@@ -55,7 +55,7 @@ const plugins = [
 	"jsx",
 	"typescript",
 	"objectRestSpread",
-	["decorators", { "decoratorsBeforeExport": true }],
+	["decorators", { "decoratorsBeforeExport": false }],
 	"classProperties",
 	"exportExtensions",
 	"asyncGenerators",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "check-coverage": true
   },
   "scripts": {
-    "test": "nyc mocha --no-timeouts"
+    "test": "nyc mocha --no-timeouts",
+    "debug": "mocha  --inspect --debug-brk --no-timeouts"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0-rc.1"
+    "@babel/core": "^7.0.0"
   },
   "optionalDependencies": {
     "postcss-styled": ">=0.33.0"


### PR DESCRIPTION
This pull request fixes an issue that does not work with `@babel/core@7.0.0`.

The reason for not working was the effect of the next change.
https://github.com/babel/babel/pull/8465