### PR TITLE
Add support for lit-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ PostCSS JSX Syntax
 - [styled-components](https://github.com/styled-components/styled-components)
 - [styletron-react](https://github.com/rtsao/styletron)
 - [typestyle](https://github.com/typestyle/typestyle)
+- [lit-css](https://github.com/bashmish/lit-css)
 
 ## Getting Started
 

--- a/extract.js
+++ b/extract.js
@@ -37,6 +37,9 @@ const supports = {
 	// https://github.com/paypal/glamorous
 	glamorous: true,
 
+	// https://github.com/bashmish/lit-css
+	"lit-css": true,
+
 	// https://github.com/js-next/react-style
 	"react-style": true,
 


### PR DESCRIPTION
`lit-css` is a new tool to distribute styles via ES modules.
The syntax it uses is exactly the same as used by `astroturf` added by #37:

```js
import { css } from 'lit-css';

export default css`
  .table {
    /* my default table styles */
  }
`;
```
Adding the support would allow us to process the CSS in tagged literals used by this library. 

This is especially important, as `lit-css` does not extract styles into `.css` files, unlike most of tools using similar syntax do. Its output is used as a content for `<style>` tags used e.g. by [lit-html](https://github.com/Polymer/lit-html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gucong3000/postcss-jsx/38)
<!-- Reviewable:end -->
